### PR TITLE
feat: lock and reshuffle behavior

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -26,6 +26,8 @@ export default function Home() {
     handleCopy,
     handleReset,
     copyConfirmed,
+    lockedNames,
+    toggleLock,
   } = useShuffler();
 
   const hasNames = names.trim().length > 0;
@@ -89,6 +91,8 @@ export default function Home() {
                       teamName={TEAM_NAMES[i] ?? `Team ${i + 1}`}
                       members={members}
                       color={legoTheme.teamColors[i % legoTheme.teamColors.length]}
+                      lockedNames={lockedNames}
+                      onToggleLock={toggleLock}
                     />
                   ))}
                 </div>

--- a/src/components/shuffler/NameBlock.tsx
+++ b/src/components/shuffler/NameBlock.tsx
@@ -5,9 +5,11 @@ import { motion, useReducedMotion } from "framer-motion";
 interface NameBlockProps {
   name: string;
   color: string;
+  locked?: boolean;
+  onToggleLock?: () => void;
 }
 
-export default function NameBlock({ name, color }: NameBlockProps) {
+export default function NameBlock({ name, color, locked, onToggleLock }: NameBlockProps) {
   const isLight = isLightColor(color);
   const textColor = isLight ? '#1A1A1A' : '#FFFFFF';
   const reducedMotion = useReducedMotion();
@@ -17,11 +19,12 @@ export default function NameBlock({ name, color }: NameBlockProps) {
       layoutId={name}
       className="relative flex items-center justify-center px-3 py-2 text-sm font-bold text-center leading-tight select-none"
       style={{
-        backgroundColor: color,
+        backgroundColor: locked ? color + 'CC' : color,
         color: textColor,
-        border: '3px solid #1A1A1A',
+        border: locked ? '3px dashed #1A1A1A' : '3px solid #1A1A1A',
         borderRadius: '4px',
-        boxShadow: '3px 3px 0px #1A1A1A',
+        boxShadow: locked ? 'none' : '3px 3px 0px #1A1A1A',
+        opacity: locked ? 0.8 : 1,
       }}
       initial={reducedMotion ? false : { opacity: 0, y: 20 }}
       animate={reducedMotion ? {} : { opacity: 1, y: 0 }}
@@ -30,6 +33,16 @@ export default function NameBlock({ name, color }: NameBlockProps) {
       whileTap={reducedMotion ? undefined : { y: 1 }}
     >
       <span className="truncate max-w-full">{name}</span>
+      {onToggleLock && (
+        <button
+          onClick={(e) => { e.stopPropagation(); onToggleLock(); }}
+          className="absolute top-0.5 right-0.5 text-xs leading-none p-0.5"
+          style={{ opacity: locked ? 1 : 0.4, lineHeight: 1 }}
+          aria-label={locked ? 'Unlock' : 'Lock'}
+        >
+          {locked ? '🔒' : '🔓'}
+        </button>
+      )}
     </motion.div>
   );
 }

--- a/src/components/shuffler/TeamContainer.tsx
+++ b/src/components/shuffler/TeamContainer.tsx
@@ -8,6 +8,8 @@ interface TeamContainerProps {
   members: string[];
   color: string;
   index: number;
+  lockedNames?: Set<string>;
+  onToggleLock?: (name: string) => void;
 }
 
 const containerVariants = {
@@ -15,7 +17,7 @@ const containerVariants = {
   visible: { transition: { staggerChildren: 0.06 } },
 };
 
-export default function TeamContainer({ teamName, members, color, index }: TeamContainerProps) {
+export default function TeamContainer({ teamName, members, color, index, lockedNames, onToggleLock }: TeamContainerProps) {
   const isLight = isLightColor(color);
   const headerTextColor = isLight ? '#1A1A1A' : '#FFFFFF';
 
@@ -32,7 +34,6 @@ export default function TeamContainer({ teamName, members, color, index }: TeamC
       transition={{ type: 'spring', stiffness: 260, damping: 20, delay: index * 0.06 }}
       variants={containerVariants}
     >
-      {/* Team header */}
       <div
         className="px-4 py-2 flex items-center gap-2"
         style={{
@@ -47,27 +48,24 @@ export default function TeamContainer({ teamName, members, color, index }: TeamC
         <span className="text-base font-black truncate">{teamName}</span>
         <span
           className="ml-auto text-xs font-bold px-2 py-0.5 rounded"
-          style={{
-            backgroundColor: 'rgba(0,0,0,0.15)',
-            color: headerTextColor,
-          }}
+          style={{ backgroundColor: 'rgba(0,0,0,0.15)', color: headerTextColor }}
         >
           {members.length}
         </span>
       </div>
 
-      {/* Members grid */}
-      <div
-        className="p-3 grid gap-2"
-        style={{ backgroundColor: '#F5F5F5' }}
-      >
+      <div className="p-3 grid gap-2" style={{ backgroundColor: '#F5F5F5' }}>
         {members.length === 0 ? (
-          <p className="text-xs text-center py-2" style={{ color: '#999' }}>
-            No members
-          </p>
+          <p className="text-xs text-center py-2" style={{ color: '#999' }}>No members</p>
         ) : (
           members.map((name) => (
-            <NameBlock key={name} name={name} color={color} />
+            <NameBlock
+              key={name}
+              name={name}
+              color={color}
+              locked={lockedNames?.has(name)}
+              onToggleLock={onToggleLock ? () => onToggleLock(name) : undefined}
+            />
           ))
         )}
       </div>

--- a/src/hooks/useShuffler.ts
+++ b/src/hooks/useShuffler.ts
@@ -6,13 +6,30 @@ export function useShuffler() {
   const [teamCount, setTeamCount] = useState(3);
   const [result, setResult] = useState<string[][] | null>(null);
   const [copyConfirmed, setCopyConfirmed] = useState(false);
+  const [lockedNames, setLockedNames] = useState<Set<string>>(new Set());
+
+  function toggleLock(name: string) {
+    setLockedNames((prev) => {
+      const next = new Set(prev);
+      if (next.has(name)) { next.delete(name); } else { next.add(name); }
+      return next;
+    });
+  }
 
   function handleShuffle() {
     const nameList = names
       .split("\n")
       .map((n) => n.trim())
       .filter(Boolean);
-    const { teams } = shuffle(nameList, teamCount);
+    const lockedAssignments: Record<string, number> = {};
+    if (result) {
+      result.forEach((team, idx) => {
+        team.forEach((name) => {
+          if (lockedNames.has(name)) lockedAssignments[name] = idx;
+        });
+      });
+    }
+    const { teams } = shuffle(nameList, teamCount, { lockedAssignments });
     setResult(teams);
   }
 
@@ -30,6 +47,7 @@ export function useShuffler() {
     setNames("");
     setTeamCount(3);
     setResult(null);
+    setLockedNames(new Set());
     setCopyConfirmed(false);
   }
 
@@ -43,5 +61,7 @@ export function useShuffler() {
     handleCopy,
     handleReset,
     copyConfirmed,
+    lockedNames,
+    toggleLock,
   };
 }


### PR DESCRIPTION
Closes #7

Lock toggle on NameBlock (padlock icon, dashed border when locked). useShuffler tracks locked names and passes lockedAssignments to shuffle(). Reset clears locks. Build and lint pass.