### PR TITLE
feat: build and push Docker image to Docker Hub

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -31,10 +31,10 @@ jobs:
           fetch-depth: 0  # full history for tag-based versioning
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@b5730abb14f7101f245643d8a4b82ae58a63d5d6  # v3.10.0
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4.0.0
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772  # v3.4.0
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2  # v4.0.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
@@ -78,7 +78,7 @@ jobs:
           fi
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@14487ce63c7a62a4a324b0bfb37086795e31c6c1  # v6.16.0
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294  # v7.0.0
         with:
           context: .
           file: ./Dockerfile


### PR DESCRIPTION
Part of #11 — Step 1 of deployment setup.

## What
Adds `.github/workflows/build-and-push.yml` that builds the Next.js Docker image and pushes to `bonditgroup/team-shuffler-frontend` on Docker Hub.

## Triggers
- Push to `main` → builds and pushes with latest semver tag for the month + `latest`
- Release published → tags with the release version + `latest`
- Manual `workflow_dispatch` → optional version override

## Versioning
Same YY.MM.PATCH strategy as `bondit-financial-dashboard`. Create a git tag (e.g. `26.3.1`) before releasing.

## Before merging ⚠️
Two secrets need to be added to the repo:
- `DOCKER_USERNAME` — Docker Hub username (`bonditgroup` or personal)
- `DOCKER_PASSWORD` — Docker Hub access token (not password — create at hub.docker.com → Account Settings → Security)

## Actions pinned to SHA ✅
- `actions/checkout` v6.0.2
- `docker/setup-buildx-action` v3.10.0
- `docker/login-action` v3.4.0
- `docker/build-push-action` v6.16.0