### PR TITLE
fix: add missing infisical-service-account to k8s chart

### DIFF
--- a/k8s/templates/serviceaccount.yaml
+++ b/k8s/templates/serviceaccount.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.infisical.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: infisical-service-account
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "team-shuffler.labels" . | nindent 4 }}
+{{- end }}


### PR DESCRIPTION
Same fix as consultant-portal-infra#109 — `infisical-service-account` ServiceAccount was missing from the prod chart template. Required by the Infisical operator to authenticate in the namespace.