### PR TITLE
fix: remove infisical identityId from app repo values-prod

### DIFF
--- a/k8s/values-prod.yaml
+++ b/k8s/values-prod.yaml
@@ -29,7 +29,5 @@ ingress:
       hosts:
         - team-shuffler.bondit.dk
 
-infisical:
-  identityId: "c40b87cc-9653-4a6d-9f16-f55fbca8ae1b"  # Shared prod identity
-  envSlug: "prod"
-  resyncInterval: 60
+# Infisical identity config lives in the infra repo (consultant-portal-infra)
+# See bootstrap/prod/applications/team-shuffler.yaml → spec.source.helm.parameters


### PR DESCRIPTION
Infrastructure identifiers (Infisical identity IDs, env slugs) should live in the infra repo, not the app repo.

Removes `infisical.identityId`, `infisical.envSlug`, and `infisical.resyncInterval` from `k8s/values-prod.yaml`. These are now injected as Helm parameters in the ArgoCD app definition in `consultant-portal-infra` (see companion PR there).

Companion: consultant-portal-infra#PR