### PR TITLE
feat: presentation mode and team name/number toggle

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -29,9 +29,22 @@ export default function Home() {
     lockedNames,
     toggleLock,
     validation,
+    useTeamNames,
+    setUseTeamNames,
   } = useShuffler();
 
   const hasNames = names.trim().length > 0;
+
+  function handleShowTeams() {
+    if (!result) return;
+    const payload = {
+      teams: result,
+      teamNames: TEAM_NAMES,
+      useTeamNames,
+    };
+    localStorage.setItem("team-shuffler-presentation", JSON.stringify(payload));
+    window.open("/present", "_blank", "noopener");
+  }
 
   return (
     <div className="flex min-h-screen flex-col" style={{ backgroundColor: legoTheme.colors.gray }}>
@@ -43,11 +56,17 @@ export default function Home() {
             onChange={setNames}
             placeholder={"Alice\nBob\nCharlie\n..."}
           />
-          <TeamCountSelector value={teamCount} onChange={setTeamCount} />
+          <TeamCountSelector
+            value={teamCount}
+            onChange={setTeamCount}
+            useTeamNames={useTeamNames}
+            onToggleTeamNames={setUseTeamNames}
+          />
           <ShuffleControls
             onShuffle={handleShuffle}
             onCopy={handleCopy}
             onReset={handleReset}
+            onShowTeams={handleShowTeams}
             hasResult={!!result}
             disabled={!hasNames || !!validation.error}
             copyConfirmed={copyConfirmed}
@@ -100,11 +119,12 @@ export default function Home() {
                     <TeamContainer
                       key={i}
                       index={i}
-                      teamName={TEAM_NAMES[i] ?? `Team ${i + 1}`}
+                      teamName={useTeamNames ? (TEAM_NAMES[i] ?? `Team ${i + 1}`) : `Team ${i + 1}`}
                       members={members}
                       color={legoTheme.teamColors[i % legoTheme.teamColors.length]}
                       lockedNames={lockedNames}
                       onToggleLock={toggleLock}
+                      showName={useTeamNames}
                     />
                   ))}
                 </div>

--- a/src/app/present/page.tsx
+++ b/src/app/present/page.tsx
@@ -1,0 +1,198 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { legoTheme } from "@/styles/themes/lego";
+
+interface PresentationData {
+  teams: string[][];
+  teamNames: string[];
+  useTeamNames: boolean;
+}
+
+function getColumnCount(n: number): number {
+  if (n === 1) return 1;
+  if (n === 2) return 2;
+  if (n === 3) return 3;
+  if (n === 4) return 2;
+  if (n <= 6) return 3;
+  return 4;
+}
+
+function isLightColor(hex: string): boolean {
+  const r = parseInt(hex.slice(1, 3), 16);
+  const g = parseInt(hex.slice(3, 5), 16);
+  const b = parseInt(hex.slice(5, 7), 16);
+  return (r * 299 + g * 587 + b * 114) / 1000 > 155;
+}
+
+export default function PresentPage() {
+  const [data, setData] = useState<PresentationData | null>(null);
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    try {
+      const raw = localStorage.getItem("team-shuffler-presentation");
+      if (!raw) { setError(true); return; }
+      setData(JSON.parse(raw));
+    } catch {
+      setError(true);
+    }
+  }, []);
+
+  if (error) {
+    return (
+      <div
+        className="flex min-h-screen items-center justify-center"
+        style={{ backgroundColor: legoTheme.colors.gray, fontFamily: legoTheme.fontFamily }}
+      >
+        <div
+          className="text-center p-8"
+          style={{
+            border: `3px solid ${legoTheme.colors.black}`,
+            borderRadius: legoTheme.borderRadius,
+            boxShadow: legoTheme.shadow,
+            backgroundColor: legoTheme.colors.white,
+          }}
+        >
+          <p className="text-xl font-black uppercase tracking-widest" style={{ color: legoTheme.colors.red }}>
+            No team data found
+          </p>
+          <p className="mt-2 text-sm font-bold" style={{ color: "#666" }}>
+            Go back to the shuffler and click &quot;Show Teams&quot; to open this page.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  if (!data) return null;
+
+  const { teams, teamNames, useTeamNames } = data;
+  const cols = getColumnCount(teams.length);
+
+  return (
+    <div
+      className="min-h-screen p-4"
+      style={{
+        backgroundColor: legoTheme.colors.black,
+        fontFamily: legoTheme.fontFamily,
+      }}
+    >
+      {/* Header bar */}
+      <div className="mb-4 flex items-center justify-between">
+        <span
+          className="text-xs font-black uppercase tracking-widest px-3 py-1"
+          style={{
+            backgroundColor: legoTheme.colors.yellow,
+            color: legoTheme.colors.black,
+            border: `2px solid ${legoTheme.colors.black}`,
+            borderRadius: legoTheme.borderRadius,
+            boxShadow: "2px 2px 0px #fff",
+          }}
+        >
+          🧱 Team Shuffler — Presentation
+        </span>
+        <span
+          className="text-xs font-bold"
+          style={{ color: "#888" }}
+        >
+          {teams.reduce((s, t) => s + t.length, 0)} members · {teams.length} teams
+        </span>
+      </div>
+
+      {/* Team grid */}
+      <div
+        className="grid gap-4"
+        style={{
+          gridTemplateColumns: `repeat(${cols}, 1fr)`,
+        }}
+      >
+        {teams.map((members, i) => {
+          const color = legoTheme.teamColors[i % legoTheme.teamColors.length];
+          const isLight = isLightColor(color);
+          const textColor = isLight ? legoTheme.colors.black : legoTheme.colors.white;
+          const label = useTeamNames
+            ? (teamNames[i] ?? `Team ${i + 1}`)
+            : `Team ${i + 1}`;
+
+          return (
+            <div
+              key={i}
+              className="flex flex-col overflow-hidden"
+              style={{
+                border: `3px solid ${legoTheme.colors.white}`,
+                borderRadius: legoTheme.borderRadius,
+                boxShadow: `4px 4px 0px ${color}`,
+              }}
+            >
+              {/* Team header */}
+              <div
+                className="px-5 py-3 flex items-baseline gap-3"
+                style={{
+                  backgroundColor: color,
+                  borderBottom: `3px solid ${legoTheme.colors.white}`,
+                }}
+              >
+                {useTeamNames && (
+                  <span
+                    className="font-black uppercase tracking-widest opacity-70"
+                    style={{ fontSize: "clamp(0.6rem, 1.2vw, 0.8rem)", color: textColor }}
+                  >
+                    Team {i + 1}
+                  </span>
+                )}
+                <span
+                  className="font-black truncate"
+                  style={{ fontSize: "clamp(1.1rem, 2.5vw, 2rem)", color: textColor }}
+                >
+                  {label}
+                </span>
+                <span
+                  className="ml-auto font-black shrink-0"
+                  style={{
+                    fontSize: "clamp(0.75rem, 1.4vw, 1rem)",
+                    color: textColor,
+                    opacity: 0.8,
+                  }}
+                >
+                  {members.length}
+                </span>
+              </div>
+
+              {/* Members */}
+              <div
+                className="flex flex-col gap-2 p-4"
+                style={{ backgroundColor: "#1e1e1e", flex: 1 }}
+              >
+                {members.map((name) => (
+                  <div
+                    key={name}
+                    className="font-black truncate"
+                    style={{
+                      fontSize: "clamp(0.9rem, 1.8vw, 1.4rem)",
+                      color: legoTheme.colors.white,
+                      padding: "6px 10px",
+                      borderLeft: `4px solid ${color}`,
+                      backgroundColor: "rgba(255,255,255,0.05)",
+                      borderRadius: "2px",
+                    }}
+                  >
+                    {name}
+                  </div>
+                ))}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Footer hint */}
+      <p
+        className="mt-4 text-center text-xs font-bold uppercase tracking-widest"
+        style={{ color: "#444" }}
+      >
+        Press F11 for fullscreen
+      </p>
+    </div>
+  );
+}

--- a/src/components/shuffler/ShuffleControls.tsx
+++ b/src/components/shuffler/ShuffleControls.tsx
@@ -4,6 +4,7 @@ interface ShuffleControlsProps {
   onShuffle: () => void;
   onCopy: () => void;
   onReset: () => void;
+  onShowTeams: () => void;
   hasResult: boolean;
   disabled?: boolean;
   copyConfirmed?: boolean;
@@ -17,7 +18,6 @@ const legoButton = {
     fontWeight: 900,
     letterSpacing: "0.1em",
     textTransform: "uppercase" as const,
-    width: "100%",
     padding: "12px 24px",
     fontSize: "0.9rem",
     cursor: "pointer",
@@ -29,6 +29,7 @@ export default function ShuffleControls({
   onShuffle,
   onCopy,
   onReset,
+  onShowTeams,
   hasResult,
   disabled = false,
   copyConfirmed = false,
@@ -40,6 +41,7 @@ export default function ShuffleControls({
         disabled={disabled}
         style={{
           ...legoButton.base,
+          width: "100%",
           backgroundColor: disabled ? "#ccc" : legoTheme.colors.red,
           color: disabled ? "#888" : legoTheme.colors.white,
           boxShadow: disabled ? "2px 2px 0px #999" : legoTheme.shadow,
@@ -62,26 +64,49 @@ export default function ShuffleControls({
 
       {hasResult && (
         <>
-          <button
-            onClick={onCopy}
-            style={{
-              ...legoButton.base,
-              backgroundColor: legoTheme.colors.blue,
-              color: legoTheme.colors.white,
-              boxShadow: legoTheme.shadow,
-            }}
-            onMouseEnter={(e) => (e.currentTarget.style.backgroundColor = "#005a9a")}
-            onMouseLeave={(e) => (e.currentTarget.style.backgroundColor = legoTheme.colors.blue)}
-            onMouseDown={(e) => (e.currentTarget.style.transform = "translate(2px, 2px)")}
-            onMouseUp={(e) => (e.currentTarget.style.transform = "")}
-          >
-            <span aria-live="polite">{copyConfirmed ? "Copied! ✓" : "Copy Results"}</span>
-          </button>
+          {/* Copy + Show Teams side by side */}
+          <div className="flex gap-2">
+            <button
+              onClick={onCopy}
+              style={{
+                ...legoButton.base,
+                flex: 1,
+                backgroundColor: legoTheme.colors.blue,
+                color: legoTheme.colors.white,
+                boxShadow: legoTheme.shadow,
+              }}
+              onMouseEnter={(e) => (e.currentTarget.style.backgroundColor = "#005a9a")}
+              onMouseLeave={(e) => (e.currentTarget.style.backgroundColor = legoTheme.colors.blue)}
+              onMouseDown={(e) => (e.currentTarget.style.transform = "translate(2px, 2px)")}
+              onMouseUp={(e) => (e.currentTarget.style.transform = "")}
+            >
+              <span aria-live="polite">{copyConfirmed ? "Copied! ✓" : "Copy Results"}</span>
+            </button>
+
+            <button
+              onClick={onShowTeams}
+              aria-label="Open presentation view"
+              style={{
+                ...legoButton.base,
+                flex: 1,
+                backgroundColor: legoTheme.colors.green,
+                color: legoTheme.colors.white,
+                boxShadow: legoTheme.shadow,
+              }}
+              onMouseEnter={(e) => (e.currentTarget.style.backgroundColor = "#008040")}
+              onMouseLeave={(e) => (e.currentTarget.style.backgroundColor = legoTheme.colors.green)}
+              onMouseDown={(e) => (e.currentTarget.style.transform = "translate(2px, 2px)")}
+              onMouseUp={(e) => (e.currentTarget.style.transform = "")}
+            >
+              Show Teams
+            </button>
+          </div>
 
           <button
             onClick={onReset}
             style={{
               ...legoButton.base,
+              width: "100%",
               backgroundColor: legoTheme.colors.white,
               color: legoTheme.colors.black,
               boxShadow: "2px 2px 0px #ccc",

--- a/src/components/shuffler/TeamContainer.tsx
+++ b/src/components/shuffler/TeamContainer.tsx
@@ -10,6 +10,7 @@ interface TeamContainerProps {
   index: number;
   lockedNames?: Set<string>;
   onToggleLock?: (name: string) => void;
+  showName?: boolean; // if false, show only "Team N"
 }
 
 const containerVariants = {
@@ -17,15 +18,25 @@ const containerVariants = {
   visible: { transition: { staggerChildren: 0.06 } },
 };
 
-export default function TeamContainer({ teamName, members, color, index, lockedNames, onToggleLock }: TeamContainerProps) {
+export default function TeamContainer({
+  teamName,
+  members,
+  color,
+  index,
+  lockedNames,
+  onToggleLock,
+  showName = true,
+}: TeamContainerProps) {
   const isLight = isLightColor(color);
   const headerTextColor = isLight ? '#1A1A1A' : '#FFFFFF';
   const reducedMotion = useReducedMotion();
 
+  const displayLabel = showName ? teamName : `Team ${index + 1}`;
+
   return (
     <motion.div
       role="region"
-      aria-label={`Team ${index + 1}: ${teamName}`}
+      aria-label={`Team ${index + 1}${showName ? `: ${teamName}` : ""}`}
       className="flex flex-col overflow-hidden"
       style={{
         border: '3px solid #1A1A1A',
@@ -45,10 +56,12 @@ export default function TeamContainer({ teamName, members, color, index, lockedN
           borderBottom: '3px solid #1A1A1A',
         }}
       >
-        <span className="text-xs font-black uppercase tracking-widest opacity-70">
-          Team {index + 1}
-        </span>
-        <span className="text-base font-black truncate">{teamName}</span>
+        {showName && (
+          <span className="text-xs font-black uppercase tracking-widest opacity-70">
+            Team {index + 1}
+          </span>
+        )}
+        <span className="text-base font-black truncate">{displayLabel}</span>
         <span
           className="ml-auto text-xs font-bold px-2 py-0.5 rounded"
           style={{ backgroundColor: 'rgba(0,0,0,0.15)', color: headerTextColor }}

--- a/src/components/shuffler/TeamCountSelector.tsx
+++ b/src/components/shuffler/TeamCountSelector.tsx
@@ -3,9 +3,16 @@ import { legoTheme } from "@/styles/themes/lego";
 interface TeamCountSelectorProps {
   value: number;
   onChange: (value: number) => void;
+  useTeamNames: boolean;
+  onToggleTeamNames: (value: boolean) => void;
 }
 
-export default function TeamCountSelector({ value, onChange }: TeamCountSelectorProps) {
+export default function TeamCountSelector({
+  value,
+  onChange,
+  useTeamNames,
+  onToggleTeamNames,
+}: TeamCountSelectorProps) {
   function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
     const parsed = parseInt(e.target.value, 10);
     if (!isNaN(parsed)) {
@@ -22,32 +29,76 @@ export default function TeamCountSelector({ value, onChange }: TeamCountSelector
       >
         Number of teams
       </label>
-      <input
-        id="team-count"
-        aria-label="Number of teams"
-        type="number"
-        min={2}
-        max={20}
-        value={value}
-        onChange={handleChange}
-        className="w-24 p-2 text-sm font-bold"
-        style={{
-          border: `${legoTheme.borderWidth} solid ${legoTheme.colors.border}`,
-          borderRadius: legoTheme.borderRadius,
-          boxShadow: legoTheme.shadow,
-          backgroundColor: legoTheme.colors.white,
-          outline: 'none',
-          fontFamily: legoTheme.fontFamily,
-        }}
-        onFocus={(e) => {
-          e.target.style.boxShadow = `4px 4px 0px ${legoTheme.colors.blue}`;
-          e.target.style.borderColor = legoTheme.colors.blue;
-        }}
-        onBlur={(e) => {
-          e.target.style.boxShadow = legoTheme.shadow;
-          e.target.style.borderColor = legoTheme.colors.border;
-        }}
-      />
+      <div className="flex items-center gap-4 flex-wrap">
+        <input
+          id="team-count"
+          aria-label="Number of teams"
+          type="number"
+          min={2}
+          max={20}
+          value={value}
+          onChange={handleChange}
+          className="w-24 p-2 text-sm font-bold"
+          style={{
+            border: `${legoTheme.borderWidth} solid ${legoTheme.colors.border}`,
+            borderRadius: legoTheme.borderRadius,
+            boxShadow: legoTheme.shadow,
+            backgroundColor: legoTheme.colors.white,
+            outline: "none",
+            fontFamily: legoTheme.fontFamily,
+          }}
+          onFocus={(e) => {
+            e.target.style.boxShadow = `4px 4px 0px ${legoTheme.colors.blue}`;
+            e.target.style.borderColor = legoTheme.colors.blue;
+          }}
+          onBlur={(e) => {
+            e.target.style.boxShadow = legoTheme.shadow;
+            e.target.style.borderColor = legoTheme.colors.border;
+          }}
+        />
+
+        <label
+          className="flex items-center gap-2 cursor-pointer select-none"
+          htmlFor="use-team-names"
+        >
+          <div className="relative">
+            <input
+              id="use-team-names"
+              type="checkbox"
+              checked={useTeamNames}
+              onChange={(e) => onToggleTeamNames(e.target.checked)}
+              className="sr-only"
+              aria-label="Use team names (Alpha, Bravo…) instead of numbers"
+            />
+            {/* LEGO-style checkbox */}
+            <div
+              className="flex items-center justify-center"
+              style={{
+                width: 24,
+                height: 24,
+                border: `3px solid ${legoTheme.colors.black}`,
+                borderRadius: legoTheme.borderRadius,
+                backgroundColor: useTeamNames ? legoTheme.colors.yellow : legoTheme.colors.white,
+                boxShadow: useTeamNames ? "2px 2px 0px #1A1A1A" : "2px 2px 0px #ccc",
+                transition: "all 0.1s",
+              }}
+              aria-hidden="true"
+            >
+              {useTeamNames && (
+                <span style={{ fontSize: 14, fontWeight: 900, color: legoTheme.colors.black, lineHeight: 1 }}>
+                  ✓
+                </span>
+              )}
+            </div>
+          </div>
+          <span
+            className="text-sm font-bold uppercase tracking-wide"
+            style={{ color: legoTheme.colors.black }}
+          >
+            Team names
+          </span>
+        </label>
+      </div>
     </div>
   );
 }

--- a/src/hooks/useShuffler.ts
+++ b/src/hooks/useShuffler.ts
@@ -36,6 +36,7 @@ export function useShuffler() {
   const [result, setResult] = useState<string[][] | null>(null);
   const [copyConfirmed, setCopyConfirmed] = useState(false);
   const [lockedNames, setLockedNames] = useState<Set<string>>(new Set());
+  const [useTeamNames, setUseTeamNames] = useState(true);
 
   const validation = validate(names, teamCount);
 
@@ -93,5 +94,7 @@ export function useShuffler() {
     lockedNames,
     toggleLock,
     validation,
+    useTeamNames,
+    setUseTeamNames,
   };
 }


### PR DESCRIPTION
Closes two UX requests from Martin.

## 1 — Show Teams (presentation mode)

A green **Show Teams** button appears next to **Copy Results** once teams are created. Clicking it stores the current result in `localStorage` and opens `/present` in a new tab.

The presentation page (`/present`) is a full-screen, dark-themed grid designed for projectors/screens:
- **Dynamic columns** based on team count: 1→1, 2→2, 3→3, 4→2×2, 5–6→3, 7+→4
- **Responsive font sizes** via `clamp()` — readable from across the room
- LEGO team colors with dark background for contrast
- Subtle **F11 hint** in the footer for fullscreen
- Handles stale/missing data gracefully with an error state

## 2 — Team names toggle

A **Team names** checkbox sits inline next to the `Number of teams` input. LEGO-styled (yellow fill when checked, black border, bold).

- ✅ Checked (default): teams show `Alpha`, `Bravo`, `Charlie`… + `Team 1` subtext
- ☐ Unchecked: teams show only `Team 1`, `Team 2`…

Toggle state is respected in both the main result grid and the presentation page.

## Files changed
- `src/hooks/useShuffler.ts` — added `useTeamNames` state
- `src/components/shuffler/TeamCountSelector.tsx` — added checkbox
- `src/components/shuffler/ShuffleControls.tsx` — added Show Teams button, Copy+Show side by side
- `src/components/shuffler/TeamContainer.tsx` — accepts `showName` prop
- `src/app/page.tsx` — wired up new props + `handleShowTeams`
- `src/app/present/page.tsx` — new presentation page