### PR TITLE
feat: LEGO monthly release workflow with PR changelog

### DIFF
--- a/.github/workflows/monthly-release.yml
+++ b/.github/workflows/monthly-release.yml
@@ -29,33 +29,16 @@ jobs:
           fetch-tags: true
 
       # ─────────────────────────────────────────────
-      # 🏷️  Calculate next version tag (YY.MM.PATCH)
+      # 🏷️  Calculate release tag (always YY.MM.0)
       # ─────────────────────────────────────────────
       - name: 🏷️ Calculate release tag
         id: release
         run: |
           YEAR=$(date +'%y')
           MONTH=$(date +'%-m')
-          PREFIX="${YEAR}.${MONTH}"
-
-          # Find the highest existing patch for this month
-          git fetch --tags
-          LATEST_PATCH=$(git tag -l "${PREFIX}.*" \
-            | grep -E "^${PREFIX}\.[0-9]+$" \
-            | sort -t. -k3 -n \
-            | tail -1 \
-            | awk -F. '{print $3}')
-
-          if [[ -z "$LATEST_PATCH" ]]; then
-            PATCH=1
-          else
-            PATCH=$((LATEST_PATCH + 1))
-          fi
-
-          TAG="${PREFIX}.${PATCH}"
-          echo "tag=${TAG}"           >> "$GITHUB_OUTPUT"
-          echo "prefix=${PREFIX}"     >> "$GITHUB_OUTPUT"
-          echo "📦 Next release tag: ${TAG}"
+          TAG="${YEAR}.${MONTH}.0"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "📦 Monthly release tag: ${TAG}"
 
       # ─────────────────────────────────────────────
       # 📋  Build LEGO-themed release notes from PRs


### PR DESCRIPTION
Adds `.github/workflows/monthly-release.yml` — similar to NextDNS but with a proper per-PR changelog.

## What it does

1. **Runs** on the 1st of each month at 01:00 UTC (02:00 CET), plus manual `workflow_dispatch`
2. **Calculates** the next `YY.MM.PATCH` tag — finds existing tags for the current month and increments the patch (e.g. if `26.3.1` exists → creates `26.3.2`)
3. **Queries** all PRs merged to `main` since the last GitHub release
4. **Groups** them by label into LEGO-themed sections:
   - 🧱 New Features (`enhancement`, `feature`, `mvp`)
   - 🔧 Bug Fixes (`bug`, `fix`)
   - 🏗️ Infrastructure (`infrastructure`, `ci`)
   - 🛡️ Security (`security`)
   - 📋 Other Changes (anything unlabelled)
5. **Creates** an annotated git tag + GitHub release with the formatted notes
6. Includes a **Dry run** toggle on manual dispatch — prints the notes without creating a release (great for previewing)

## Example release note output
```
## 🧱 Team Shuffler — March 2026

> Another month, another set of LEGO bricks snapping into place!

### 🧱 New Features
- **Add presentation mode and team name toggle** (#38) — @MaBoNi `enhancement` `mvp`
- **Add sample-names.txt with 100 names** (#39) — @MaBoNi `enhancement`

### 🔧 Bug Fixes
- **Fix missing infisical-service-account in chart** (#109) — @MaBoNi `bug`

### 🏗️ Infrastructure
- **Add team-shuffler Helm chart and ArgoCD apps** (#108) — @MaBoNi `infrastructure`
```