### PR TITLE
chore: upgrade postgres to 18 in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
   #   restart: unless-stopped
   #
   # db:
-  #   image: postgres:15
+  #   image: postgres:18
   #   env_file: .env.local
   #   ports:
   #     - "5432:5432"


### PR DESCRIPTION
## Summary
Aligns local dev PostgreSQL version with the DO managed database upgrade to PostgreSQL 18.

## Changes
- `docker-compose.yml`: bumped `postgres:15` → `postgres:18`

## Release Notes
```
chore: upgrade local dev postgres from 15 to 18 to match DO managed database (PostgreSQL 18.3)
```

## Testing
Run `docker-compose up` locally and verify database starts cleanly on postgres:18.