### PR TITLE
feat(present): fully responsive no-scroll presentation page

### DIFF
--- a/src/app/present/page.tsx
+++ b/src/app/present/page.tsx
@@ -45,12 +45,19 @@ export default function PresentPage() {
   if (error) {
     return (
       <div
-        className="flex min-h-screen items-center justify-center"
-        style={{ backgroundColor: legoTheme.colors.gray, fontFamily: legoTheme.fontFamily }}
+        style={{
+          display: "flex",
+          minHeight: "100dvh",
+          alignItems: "center",
+          justifyContent: "center",
+          backgroundColor: legoTheme.colors.gray,
+          fontFamily: legoTheme.fontFamily,
+        }}
       >
         <div
-          className="text-center p-8"
           style={{
+            textAlign: "center",
+            padding: "32px",
             border: `3px solid ${legoTheme.colors.black}`,
             borderRadius: legoTheme.borderRadius,
             boxShadow: legoTheme.shadow,
@@ -58,12 +65,17 @@ export default function PresentPage() {
           }}
         >
           <p
-            className="text-xl font-black uppercase tracking-widest"
-            style={{ color: legoTheme.colors.red }}
+            style={{
+              fontSize: "1.25rem",
+              fontWeight: 900,
+              textTransform: "uppercase",
+              letterSpacing: "0.1em",
+              color: legoTheme.colors.red,
+            }}
           >
             No team data found
           </p>
-          <p className="mt-2 text-sm font-bold" style={{ color: "#666" }}>
+          <p style={{ marginTop: "8px", fontSize: "0.875rem", fontWeight: 700, color: "#666" }}>
             Go back to the shuffler and click &quot;Show Teams&quot; to open this page.
           </p>
         </div>
@@ -75,39 +87,102 @@ export default function PresentPage() {
 
   const { teams, teamNames, useTeamNames } = data;
   const cols = getColumnCount(teams.length);
+  const rows = Math.ceil(teams.length / cols);
+  const maxMembers = Math.max(...teams.map((t) => t.length));
+  const totalMembers = teams.reduce((s, t) => s + t.length, 0);
+
+  // Dynamic font sizes via CSS calc + custom properties so everything fits
+  // in exactly 100dvh without any scrolling, regardless of team/member count.
+  //
+  // Layout budget:
+  //   100dvh
+  //   - outer padding:  24px  (12px top + bottom)
+  //   - header:         40px
+  //   - header gap:      8px
+  //   - grid row gaps:  10px × (rows − 1)
+  //   ─────────────────────────────────────
+  //   per card height:  (100dvh − 72px − 10px × rows) / rows
+  //
+  //   per card:
+  //   - card borders:    6px  (3px × 2)
+  //   - team header:    ~44px (padding 10px×2 + text + border)
+  //   - member padding: 16px  (8px × 2)
+  //   ─────────────────────────────────────
+  //   member area:  card − 66px
+  //   per member:   member area / maxMembers  (flex:1 distributes equally)
+  //   font size:    per member × 0.55  (line-height headroom)
+  //
+  // Expressed as CSS calc (CSS vars carry rows + maxMembers):
+  //   memberFontSize = clamp(0.5rem,
+  //     ((100dvh − 72px) / var(--rows) − 10px − 66px) / var(--max-members) * 0.55,
+  //     1.6rem)
+
+  const cssVars = {
+    "--rows": rows,
+    "--max-members": maxMembers,
+  } as React.CSSProperties;
+
+  const memberFontSize =
+    "clamp(0.5rem, calc(((100dvh - 72px) / var(--rows) - 76px) / var(--max-members) * 0.55), 1.6rem)";
+
+  const teamNameFontSize =
+    "clamp(0.85rem, calc((100dvh - 72px) / var(--rows) * 0.13), 1.8rem)";
 
   return (
     <div
-      className="min-h-screen p-4"
       style={{
+        height: "100dvh",
+        display: "flex",
+        flexDirection: "column",
+        overflow: "hidden",
         backgroundColor: legoTheme.colors.black,
         fontFamily: legoTheme.fontFamily,
+        padding: "12px",
+        boxSizing: "border-box",
+        gap: "8px",
+        ...cssVars,
       }}
     >
-      {/* Header bar */}
-      <div className="mb-4 flex items-center justify-between">
+      {/* ── Header ────────────────────────────────────────────────────── */}
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          height: "40px",
+          flexShrink: 0,
+        }}
+      >
         <span
-          className="text-xs font-black uppercase tracking-widest px-3 py-1"
           style={{
             backgroundColor: legoTheme.colors.yellow,
             color: legoTheme.colors.black,
             border: `2px solid ${legoTheme.colors.black}`,
             borderRadius: legoTheme.borderRadius,
+            padding: "3px 12px",
+            fontSize: "11px",
+            fontWeight: 900,
+            textTransform: "uppercase",
+            letterSpacing: "0.1em",
             boxShadow: "2px 2px 0px #fff",
           }}
         >
-          🧱 Team Shuffler — Presentation
+          Team Shuffler — Presentation
         </span>
-        <span className="text-xs font-bold" style={{ color: "#888" }}>
-          {teams.reduce((s, t) => s + t.length, 0)} members · {teams.length} teams
+        <span style={{ color: "#888", fontSize: "11px", fontWeight: 700 }}>
+          {totalMembers} members · {teams.length} teams
         </span>
       </div>
 
-      {/* Team grid */}
+      {/* ── Team grid ─────────────────────────────────────────────────── */}
       <div
-        className="grid gap-4"
         style={{
+          display: "grid",
           gridTemplateColumns: `repeat(${cols}, 1fr)`,
+          gridTemplateRows: `repeat(${rows}, 1fr)`,
+          gap: "10px",
+          flex: 1,
+          minHeight: 0,
         }}
       >
         {teams.map((members, i) => {
@@ -119,8 +194,10 @@ export default function PresentPage() {
           return (
             <div
               key={i}
-              className="flex flex-col overflow-hidden"
               style={{
+                display: "flex",
+                flexDirection: "column",
+                overflow: "hidden",
                 border: `3px solid ${legoTheme.colors.white}`,
                 borderRadius: legoTheme.borderRadius,
                 boxShadow: `4px 4px 0px ${color}`,
@@ -128,54 +205,87 @@ export default function PresentPage() {
             >
               {/* Team header */}
               <div
-                className="px-5 py-3 flex items-baseline gap-3"
                 style={{
                   backgroundColor: color,
                   borderBottom: `3px solid ${legoTheme.colors.white}`,
+                  padding: "10px 14px",
+                  display: "flex",
+                  alignItems: "baseline",
+                  gap: "8px",
+                  flexShrink: 0,
                 }}
               >
                 {useTeamNames && (
                   <span
-                    className="font-black uppercase tracking-widest opacity-70"
-                    style={{ fontSize: "clamp(0.6rem, 1.2vw, 0.8rem)", color: textColor }}
+                    style={{
+                      fontSize: "clamp(0.5rem, 1vw, 0.7rem)",
+                      fontWeight: 900,
+                      textTransform: "uppercase",
+                      letterSpacing: "0.1em",
+                      opacity: 0.7,
+                      color: textColor,
+                    }}
                   >
                     Team {i + 1}
                   </span>
                 )}
                 <span
-                  className="font-black truncate"
-                  style={{ fontSize: "clamp(1.1rem, 2.5vw, 2rem)", color: textColor }}
+                  style={{
+                    fontSize: teamNameFontSize,
+                    fontWeight: 900,
+                    color: textColor,
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                    whiteSpace: "nowrap",
+                    flex: 1,
+                  }}
                 >
                   {label}
                 </span>
                 <span
-                  className="ml-auto font-black shrink-0"
                   style={{
-                    fontSize: "clamp(0.75rem, 1.4vw, 1rem)",
+                    fontSize: "clamp(0.65rem, 1.2vw, 0.9rem)",
+                    fontWeight: 900,
                     color: textColor,
                     opacity: 0.8,
+                    flexShrink: 0,
                   }}
                 >
                   {members.length}
                 </span>
               </div>
 
-              {/* Members */}
+              {/* Member list — fills remaining card height with equal rows */}
               <div
-                className="flex flex-col gap-2 p-4"
-                style={{ backgroundColor: "#1e1e1e", flex: 1 }}
+                style={{
+                  backgroundColor: "#1e1e1e",
+                  flex: 1,
+                  minHeight: 0,
+                  overflow: "hidden",
+                  padding: "8px",
+                  display: "flex",
+                  flexDirection: "column",
+                  gap: "4px",
+                }}
               >
                 {members.map((name) => (
                   <div
                     key={name}
-                    className="font-black truncate"
                     style={{
-                      fontSize: "clamp(0.9rem, 1.8vw, 1.4rem)",
+                      flex: 1,
+                      minHeight: 0,
+                      display: "flex",
+                      alignItems: "center",
+                      fontSize: memberFontSize,
+                      fontWeight: 900,
                       color: legoTheme.colors.white,
-                      padding: "6px 10px",
+                      padding: "0 10px",
                       borderLeft: `4px solid ${color}`,
                       backgroundColor: "rgba(255,255,255,0.05)",
                       borderRadius: "2px",
+                      overflow: "hidden",
+                      whiteSpace: "nowrap",
+                      textOverflow: "ellipsis",
                     }}
                   >
                     {name}
@@ -186,14 +296,6 @@ export default function PresentPage() {
           );
         })}
       </div>
-
-      {/* Footer hint */}
-      <p
-        className="mt-4 text-center text-xs font-bold uppercase tracking-widest"
-        style={{ color: "#444" }}
-      >
-        Press F11 for fullscreen
-      </p>
     </div>
   );
 }


### PR DESCRIPTION
## What

Rewrites the presentation page so all teams are always visible without scrolling, regardless of screen size, number of teams, or number of members.

## How

- **`height: 100dvh` + `overflow: hidden`** on the outer container — locks layout to the viewport
- **CSS grid with `gridTemplateRows: repeat(rows, 1fr)`** — equal-height rows that fill all available space
- **`flex: 1` on each member item** — members distribute equally within their card's available height
- **Dynamic font sizing via CSS `calc()` + custom properties** (`--rows`, `--max-members`):
  - Member font: `clamp(0.5rem, ((100dvh - overhead) / rows / maxMembers) * 0.55, 1.6rem)`
  - Team name font: `clamp(0.85rem, row_height * 0.13, 1.8rem)`
- Works at any screen size — resize the window and everything reflows automatically
- Removed the footer hint (no longer needed)