### PR TITLE
✨ feat: cookie consent, GA4 analytics, OG meta tags (#54, #53, #59)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,9 @@
 NODE_ENV=development
 TEAMSHUFFLER_APP_URL=http://localhost:3000
 
+# ── Analytics ─────────────────────────────────────────────────────────────────
+NEXT_PUBLIC_GA_ID=G-XXXXXXXXXX
+
 # ── Future Platform ───────────────────────────────────────────────────────────
 # Uncomment when backend/database support is added (see Future Platform issues)
 #

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,15 +1,73 @@
 import type { Metadata } from "next";
+import Script from "next/script";
 import "./globals.css";
+import { CookieConsentBanner } from "@/components/ui/CookieConsentBanner";
+
+const APP_URL = "https://team-shuffler.bondit.dk";
+const GA_ID = process.env.NEXT_PUBLIC_GA_ID;
 
 export const metadata: Metadata = {
   title: "Team Shuffler",
-  description: "Randomly shuffle people into teams",
+  description:
+    "Randomly shuffle people into teams — perfect for workshops and retrospectives",
+  metadataBase: new URL(APP_URL),
+  alternates: {
+    canonical: APP_URL,
+  },
+  openGraph: {
+    title: "Team Shuffler",
+    description:
+      "Randomly shuffle people into teams — perfect for workshops and retrospectives",
+    url: APP_URL,
+    images: [
+      {
+        url: `${APP_URL}/opengraph-image`,
+        width: 1200,
+        height: 630,
+        alt: "Team Shuffler",
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Team Shuffler",
+    description:
+      "Randomly shuffle people into teams — perfect for workshops and retrospectives",
+    images: [`${APP_URL}/opengraph-image`],
+  },
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body>
+        {children}
+        <CookieConsentBanner />
+        {GA_ID && (
+          <>
+            <Script
+              id="ga-init"
+              strategy="afterInteractive"
+              dangerouslySetInnerHTML={{
+                __html: `
+                  (function() {
+                    if (localStorage.getItem('cookie_consent') !== 'true') return;
+                    var s = document.createElement('script');
+                    s.src = 'https://www.googletagmanager.com/gtag/js?id=${GA_ID}';
+                    s.async = true;
+                    document.head.appendChild(s);
+                    window.dataLayer = window.dataLayer || [];
+                    function gtag(){dataLayer.push(arguments);}
+                    window.gtag = gtag;
+                    gtag('js', new Date());
+                    gtag('config', '${GA_ID}');
+                  })();
+                `,
+              }}
+            />
+          </>
+        )}
+      </body>
     </html>
   );
 }

--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -1,0 +1,64 @@
+import { ImageResponse } from "next/og";
+
+export const runtime = "edge";
+export const alt = "Team Shuffler";
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+export default function OGImage() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "1200px",
+          height: "630px",
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          justifyContent: "center",
+          backgroundColor: "#FFD700",
+          fontFamily: "Arial, sans-serif",
+        }}
+      >
+        <div
+          style={{
+            border: "8px solid #1A1A1A",
+            borderRadius: "8px",
+            padding: "60px 80px",
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            backgroundColor: "#FFD700",
+            boxShadow: "8px 8px 0px #1A1A1A",
+          }}
+        >
+          <div
+            style={{
+              fontSize: "96px",
+              fontWeight: 900,
+              color: "#1A1A1A",
+              letterSpacing: "-2px",
+              lineHeight: 1,
+              marginBottom: "24px",
+            }}
+          >
+            Team Shuffler
+          </div>
+          <div
+            style={{
+              fontSize: "36px",
+              fontWeight: 700,
+              color: "#1A1A1A",
+              textAlign: "center",
+              lineHeight: 1.4,
+              maxWidth: "800px",
+            }}
+          >
+            Randomly shuffle people into teams — perfect for workshops and retrospectives
+          </div>
+        </div>
+      </div>
+    ),
+    { width: 1200, height: 630 },
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,6 +8,7 @@ import ShuffleControls from "@/components/shuffler/ShuffleControls";
 import TeamContainer from "@/components/shuffler/TeamContainer";
 import { useShuffler } from "@/hooks/useShuffler";
 import { legoTheme } from "@/styles/themes/lego";
+import { trackEvent } from "@/lib/analytics";
 import { AnimatePresence, motion } from "framer-motion";
 
 const TEAM_NAMES = ["Alpha", "Bravo", "Charlie", "Delta", "Echo", "Foxtrot", "Golf", "Hotel"];
@@ -41,6 +42,7 @@ export default function Home() {
     };
     localStorage.setItem("team-shuffler-presentation", JSON.stringify(payload));
     window.open("/present", "_blank", "noopener");
+    trackEvent("present_teams");
   }
 
   return (

--- a/src/components/ui/CookieConsentBanner.tsx
+++ b/src/components/ui/CookieConsentBanner.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { legoTheme } from "@/styles/themes/lego";
+
+const CONSENT_KEY = "cookie_consent";
+
+export function CookieConsentBanner() {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const stored = localStorage.getItem(CONSENT_KEY);
+    if (stored === null) {
+      setVisible(true);
+    }
+  }, []);
+
+  function accept() {
+    localStorage.setItem(CONSENT_KEY, "true");
+    setVisible(false);
+    // Reload so the GA snippet picks up the new consent state
+    window.location.reload();
+  }
+
+  function decline() {
+    localStorage.setItem(CONSENT_KEY, "false");
+    setVisible(false);
+  }
+
+  if (!visible) return null;
+
+  return (
+    <div
+      role="dialog"
+      aria-label="Cookie consent"
+      style={{
+        position: "fixed",
+        bottom: "1rem",
+        left: "50%",
+        transform: "translateX(-50%)",
+        zIndex: 9999,
+        width: "min(480px, calc(100vw - 2rem))",
+        backgroundColor: legoTheme.colors.white,
+        border: `${legoTheme.borderWidth} solid ${legoTheme.colors.border}`,
+        borderRadius: legoTheme.borderRadius,
+        boxShadow: legoTheme.shadow,
+        padding: "1rem 1.25rem",
+        fontFamily: legoTheme.fontFamily,
+      }}
+    >
+      <p
+        style={{
+          margin: "0 0 0.75rem",
+          fontSize: "0.875rem",
+          fontWeight: 700,
+          color: legoTheme.colors.black,
+          lineHeight: 1.5,
+        }}
+      >
+        🍪 We use cookies to improve your experience. Analytics help us understand how Team
+        Shuffler is used.
+      </p>
+      <div style={{ display: "flex", gap: "0.5rem" }}>
+        <button
+          onClick={accept}
+          style={{
+            flex: 1,
+            padding: "0.5rem 1rem",
+            backgroundColor: legoTheme.colors.yellow,
+            color: legoTheme.colors.black,
+            border: `${legoTheme.borderWidth} solid ${legoTheme.colors.border}`,
+            borderRadius: legoTheme.borderRadius,
+            fontFamily: legoTheme.fontFamily,
+            fontWeight: 800,
+            fontSize: "0.875rem",
+            cursor: "pointer",
+            boxShadow: legoTheme.shadow,
+          }}
+        >
+          Accept
+        </button>
+        <button
+          onClick={decline}
+          style={{
+            flex: 1,
+            padding: "0.5rem 1rem",
+            backgroundColor: legoTheme.colors.gray,
+            color: legoTheme.colors.black,
+            border: `${legoTheme.borderWidth} solid ${legoTheme.colors.border}`,
+            borderRadius: legoTheme.borderRadius,
+            fontFamily: legoTheme.fontFamily,
+            fontWeight: 800,
+            fontSize: "0.875rem",
+            cursor: "pointer",
+            boxShadow: legoTheme.shadow,
+          }}
+        >
+          Decline
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/useShuffler.ts
+++ b/src/hooks/useShuffler.ts
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { shuffle } from "@/lib/shuffle";
+import { trackEvent } from "@/lib/analytics";
 
 interface ValidationResult {
   nameList: string[];
@@ -64,6 +65,10 @@ export function useShuffler() {
     }
     const { teams } = shuffle(validation.nameList, teamCount, { lockedAssignments });
     setResult(teams);
+    trackEvent("shuffle", {
+      team_count: teamCount,
+      participant_count: validation.nameList.length,
+    });
   }
 
   function handleCopy() {
@@ -72,6 +77,7 @@ export function useShuffler() {
     navigator.clipboard.writeText(text);
     setCopyConfirmed(true);
     setTimeout(() => setCopyConfirmed(false), 2000);
+    trackEvent("copy_teams");
   }
 
   function handleReset() {
@@ -80,6 +86,7 @@ export function useShuffler() {
     setResult(null);
     setLockedNames(new Set());
     setCopyConfirmed(false);
+    trackEvent("reset");
   }
 
   return {

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,0 +1,14 @@
+declare global {
+  interface Window {
+    gtag?: (...args: unknown[]) => void;
+  }
+}
+
+export function trackEvent(
+  name: "shuffle" | "copy_teams" | "present_teams" | "reset",
+  params?: Record<string, unknown>,
+): void {
+  if (typeof window === "undefined") return;
+  if (typeof window.gtag !== "function") return;
+  window.gtag("event", name, params ?? {});
+}


### PR DESCRIPTION
## Summary

Implements three MVP features:

### #54 — Cookie consent banner (GDPR)
- Lightweight custom `CookieConsentBanner` component
- Shown on first visit if no `localStorage` key `cookie_consent` is set
- Accept / Decline buttons — stores `true`/`false`
- Non-blocking, floats at bottom of screen
- LEGO-themed styling

### #53 — GA4 analytics integration
- GA snippet via `next/script` with `strategy="afterInteractive"`
- Only fires after cookie consent is accepted
- Measurement ID from env var `NEXT_PUBLIC_GA_ID` (Infisical: `TEAMSHUFFLER_GA_MEASUREMENT_ID`)
- Reusable `trackEvent` helper in `src/lib/analytics.ts`
- Tracks: `shuffle`, `copy_teams`, `present_teams`, `reset`

### #59 — Meta tags + Open Graph image
- Full OG + Twitter card metadata in `layout.tsx`
- Dynamic OG image via `next/og` (`src/app/opengraph-image.tsx`) — 1200×630, LEGO yellow theme
- Canonical URL: https://team-shuffler.bondit.dk

## Closes
Fixes #54, #53, #59