### PR TITLE
✨ feat: PNG export and QR code on present view (#55, #56)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,9 @@
       "version": "0.1.0",
       "dependencies": {
         "framer-motion": "^12.35.2",
+        "html-to-image": "^1.11.13",
         "next": "^16.2.0",
+        "qrcode.react": "^4.2.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
       },
@@ -5751,6 +5753,12 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
+    "node_modules/html-to-image": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/html-to-image/-/html-to-image-1.11.13.tgz",
+      "integrity": "sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg==",
+      "license": "MIT"
+    },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
@@ -7431,6 +7439,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/qrcode.react": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/qrcode.react/-/qrcode.react-4.2.0.tgz",
+      "integrity": "sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/queue-microtask": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
   },
   "dependencies": {
     "framer-motion": "^12.35.2",
+    "html-to-image": "^1.11.13",
     "next": "^16.2.0",
+    "qrcode.react": "^4.2.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useRef } from "react";
 import Header from "@/components/layout/Header";
 import Footer from "@/components/layout/Footer";
 import NameInput from "@/components/shuffler/NameInput";
@@ -9,6 +10,7 @@ import TeamContainer from "@/components/shuffler/TeamContainer";
 import { useShuffler } from "@/hooks/useShuffler";
 import { legoTheme } from "@/styles/themes/lego";
 import { AnimatePresence, motion } from "framer-motion";
+import { toPng } from "html-to-image";
 
 const TEAM_NAMES = ["Alpha", "Bravo", "Charlie", "Delta", "Echo", "Foxtrot", "Golf", "Hotel"];
 
@@ -30,6 +32,7 @@ export default function Home() {
     setUseTeamNames,
   } = useShuffler();
 
+  const teamGridRef = useRef<HTMLDivElement>(null);
   const hasNames = names.trim().length > 0;
 
   function handleShowTeams() {
@@ -41,6 +44,37 @@ export default function Home() {
     };
     localStorage.setItem("team-shuffler-presentation", JSON.stringify(payload));
     window.open("/present", "_blank", "noopener");
+  }
+
+  async function handleExport() {
+    if (!teamGridRef.current) return;
+    const today = new Date().toISOString().slice(0, 10);
+    const filename = `teams-${today}.png`;
+
+    try {
+      const dataUrl = await toPng(teamGridRef.current, {
+        backgroundColor: legoTheme.colors.gray,
+        pixelRatio: 2,
+      });
+
+      if (typeof navigator !== "undefined" && navigator.share) {
+        const blob = await (await fetch(dataUrl)).blob();
+        const file = new File([blob], filename, { type: "image/png" });
+        try {
+          await navigator.share({ files: [file], title: "Team Shuffler Results" });
+          return;
+        } catch {
+          // Fall through to standard download if share is cancelled or unsupported
+        }
+      }
+
+      const link = document.createElement("a");
+      link.href = dataUrl;
+      link.download = filename;
+      link.click();
+    } catch (err) {
+      console.error("Export failed:", err);
+    }
   }
 
   return (
@@ -60,6 +94,7 @@ export default function Home() {
             onCopy={handleCopy}
             onReset={handleReset}
             onShowTeams={handleShowTeams}
+            onExport={handleExport}
             hasResult={!!result}
             disabled={!hasNames || !!validation.error}
             copyConfirmed={copyConfirmed}
@@ -111,6 +146,7 @@ export default function Home() {
                   teams
                 </p>
                 <div
+                  ref={teamGridRef}
                   className="grid gap-4"
                   style={{ gridTemplateColumns: "repeat(auto-fill, minmax(180px, 1fr))" }}
                 >

--- a/src/app/present/page.tsx
+++ b/src/app/present/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { QRCodeSVG } from "qrcode.react";
 import { legoTheme } from "@/styles/themes/lego";
 
 interface PresentationData {
@@ -28,6 +29,8 @@ function isLightColor(hex: string): boolean {
 export default function PresentPage() {
   const [data, setData] = useState<PresentationData | null>(null);
   const [error, setError] = useState(false);
+  const [showQr, setShowQr] = useState(true);
+  const [pageUrl, setPageUrl] = useState("");
 
   useEffect(() => {
     try {
@@ -40,6 +43,7 @@ export default function PresentPage() {
     } catch {
       setError(true);
     }
+    setPageUrl(window.location.href);
   }, []);
 
   if (error) {
@@ -296,6 +300,69 @@ export default function PresentPage() {
           );
         })}
       </div>
+
+      {/* ── QR code overlay ───────────────────────────────────────────── */}
+      {/* Toggle button */}
+      <button
+        onClick={() => setShowQr((v) => !v)}
+        aria-label={showQr ? "Hide QR code" : "Show QR code"}
+        style={{
+          position: "fixed",
+          bottom: showQr ? "196px" : "16px",
+          right: "16px",
+          zIndex: 50,
+          backgroundColor: legoTheme.colors.yellow,
+          color: legoTheme.colors.black,
+          border: `2px solid ${legoTheme.colors.black}`,
+          borderRadius: legoTheme.borderRadius,
+          fontFamily: legoTheme.fontFamily,
+          fontWeight: 900,
+          fontSize: "11px",
+          letterSpacing: "0.1em",
+          textTransform: "uppercase",
+          padding: "4px 10px",
+          cursor: "pointer",
+          boxShadow: "2px 2px 0px #fff",
+          transition: "bottom 0.2s ease",
+        }}
+      >
+        QR
+      </button>
+
+      {/* QR panel */}
+      {showQr && pageUrl && (
+        <div
+          style={{
+            position: "fixed",
+            bottom: "16px",
+            right: "16px",
+            zIndex: 40,
+            backgroundColor: legoTheme.colors.white,
+            border: `3px solid ${legoTheme.colors.black}`,
+            borderRadius: legoTheme.borderRadius,
+            boxShadow: legoTheme.shadow,
+            padding: "10px",
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            gap: "6px",
+          }}
+        >
+          <QRCodeSVG value={pageUrl} size={140} bgColor="#ffffff" fgColor="#1A1A1A" />
+          <span
+            style={{
+              fontFamily: legoTheme.fontFamily,
+              fontWeight: 900,
+              fontSize: "9px",
+              textTransform: "uppercase",
+              letterSpacing: "0.12em",
+              color: legoTheme.colors.black,
+            }}
+          >
+            Scan to open
+          </span>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/shuffler/ShuffleControls.tsx
+++ b/src/components/shuffler/ShuffleControls.tsx
@@ -5,6 +5,7 @@ interface ShuffleControlsProps {
   onCopy: () => void;
   onReset: () => void;
   onShowTeams: () => void;
+  onExport: () => void;
   hasResult: boolean;
   disabled?: boolean;
   copyConfirmed?: boolean;
@@ -30,6 +31,7 @@ export default function ShuffleControls({
   onCopy,
   onReset,
   onShowTeams,
+  onExport,
   hasResult,
   disabled = false,
   copyConfirmed = false,
@@ -101,6 +103,27 @@ export default function ShuffleControls({
               Show Teams
             </button>
           </div>
+
+          {/* Download as image */}
+          <button
+            onClick={onExport}
+            aria-label="Download teams as PNG image"
+            style={{
+              ...legoButton.base,
+              width: "100%",
+              backgroundColor: legoTheme.colors.orange,
+              color: legoTheme.colors.white,
+              boxShadow: legoTheme.shadow,
+            }}
+            onMouseEnter={(e) => (e.currentTarget.style.backgroundColor = "#c96310")}
+            onMouseLeave={(e) =>
+              (e.currentTarget.style.backgroundColor = legoTheme.colors.orange)
+            }
+            onMouseDown={(e) => (e.currentTarget.style.transform = "translate(2px, 2px)")}
+            onMouseUp={(e) => (e.currentTarget.style.transform = "")}
+          >
+            Download as Image
+          </button>
 
           <button
             onClick={onReset}


### PR DESCRIPTION
## Summary

Implements two MVP features:

### #55 — Export teams as PNG image
- "Download as image" button in `ShuffleControls` — appears after shuffle alongside Copy/Present
- Uses `html-to-image` for client-side canvas export
- File named `teams-YYYY-MM-DD.png`
- Works on mobile (triggers native share/save)

### #56 — QR code on presentation view
- QR code in bottom-right corner of `/present` view
- Encodes current page URL for attendees to scan
- Toggleable (visible by default)
- Uses `qrcode.react` — white background, LEGO-themed border

## Closes
Fixes #55, #56