### PR TITLE
✨ feat: shuffle history and drag-to-reassign (#57, #58)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "team-shuffler",
       "version": "0.1.0",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
         "framer-motion": "^12.35.2",
         "html-to-image": "^1.11.13",
         "next": "^16.2.0",
@@ -549,6 +551,59 @@
       "license": "MIT",
       "engines": {
         "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@emnapi/core": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "test": "vitest run --passWithNoTests"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
     "framer-motion": "^12.35.2",
     "html-to-image": "^1.11.13",
     "next": "^16.2.0",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -12,6 +12,14 @@ import { legoTheme } from "@/styles/themes/lego";
 import { trackEvent } from "@/lib/analytics";
 import { AnimatePresence, motion } from "framer-motion";
 import { toPng } from "html-to-image";
+import {
+  DndContext,
+  DragEndEvent,
+  MouseSensor,
+  TouchSensor,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core";
 
 const TEAM_NAMES = ["Alpha", "Bravo", "Charlie", "Delta", "Echo", "Foxtrot", "Golf", "Hotel"];
 
@@ -31,10 +39,38 @@ export default function Home() {
     validation,
     useTeamNames,
     setUseTeamNames,
+    canGoBack,
+    canGoForward,
+    historyBack,
+    historyForward,
+    moveParticipant,
   } = useShuffler();
 
   const teamGridRef = useRef<HTMLDivElement>(null);
   const hasNames = names.trim().length > 0;
+
+  const sensors = useSensors(
+    useSensor(MouseSensor, { activationConstraint: { distance: 5 } }),
+    useSensor(TouchSensor, { activationConstraint: { delay: 100, tolerance: 5 } })
+  );
+
+  function handleDragEnd(event: DragEndEvent) {
+    const { active, over } = event;
+    if (!over || !result) return;
+
+    const activeId = active.id as string;
+    const overId = over.id as string;
+
+    const [fromTeamStr, fromIndexStr] = activeId.split(":");
+    const fromTeam = parseInt(fromTeamStr, 10);
+    const fromIndex = parseInt(fromIndexStr, 10);
+
+    if (!overId.startsWith("team-")) return;
+    const toTeam = parseInt(overId.replace("team-", ""), 10);
+
+    if (fromTeam === toTeam) return;
+    moveParticipant(fromTeam, fromIndex, toTeam);
+  }
 
   function handleShowTeams() {
     if (!result) return;
@@ -97,7 +133,11 @@ export default function Home() {
             onReset={handleReset}
             onShowTeams={handleShowTeams}
             onExport={handleExport}
+            onHistoryBack={historyBack}
+            onHistoryForward={historyForward}
             hasResult={!!result}
+            canGoBack={canGoBack}
+            canGoForward={canGoForward}
             disabled={!hasNames || !!validation.error}
             copyConfirmed={copyConfirmed}
           />
@@ -147,24 +187,29 @@ export default function Home() {
                   {result.reduce((sum, t) => sum + t.length, 0)} members &mdash; {result.length}{" "}
                   teams
                 </p>
-                <div
-                  ref={teamGridRef}
-                  className="grid gap-4"
-                  style={{ gridTemplateColumns: "repeat(auto-fill, minmax(180px, 1fr))" }}
-                >
-                  {result.map((members, i) => (
-                    <TeamContainer
-                      key={i}
-                      index={i}
-                      teamName={useTeamNames ? (TEAM_NAMES[i] ?? `Team ${i + 1}`) : `Team ${i + 1}`}
-                      members={members}
-                      color={legoTheme.teamColors[i % legoTheme.teamColors.length]}
-                      lockedNames={lockedNames}
-                      onToggleLock={toggleLock}
-                      showName={useTeamNames}
-                    />
-                  ))}
-                </div>
+                <DndContext sensors={sensors} onDragEnd={handleDragEnd}>
+                  <div
+                    ref={teamGridRef}
+                    className="grid gap-4"
+                    style={{ gridTemplateColumns: "repeat(auto-fill, minmax(180px, 1fr))" }}
+                  >
+                    {result.map((members, i) => (
+                      <TeamContainer
+                        key={i}
+                        index={i}
+                        teamName={
+                          useTeamNames ? (TEAM_NAMES[i] ?? `Team ${i + 1}`) : `Team ${i + 1}`
+                        }
+                        members={members}
+                        color={legoTheme.teamColors[i % legoTheme.teamColors.length]}
+                        lockedNames={lockedNames}
+                        onToggleLock={toggleLock}
+                        showName={useTeamNames}
+                        draggable
+                      />
+                    ))}
+                  </div>
+                </DndContext>
               </motion.div>
             )}
           </AnimatePresence>

--- a/src/components/shuffler/DraggableMember.tsx
+++ b/src/components/shuffler/DraggableMember.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { useDraggable } from "@dnd-kit/core";
+import { motion, useReducedMotion } from "framer-motion";
+
+interface DraggableMemberProps {
+  id: string;
+  name: string;
+  color: string;
+  teamIndex: number;
+  memberIndex: number;
+  locked?: boolean;
+  onToggleLock?: () => void;
+}
+
+function isLightColor(hex: string): boolean {
+  const r = parseInt(hex.slice(1, 3), 16);
+  const g = parseInt(hex.slice(3, 5), 16);
+  const b = parseInt(hex.slice(5, 7), 16);
+  return (r * 299 + g * 587 + b * 114) / 1000 > 155;
+}
+
+export default function DraggableMember({
+  id,
+  name,
+  color,
+  locked,
+  onToggleLock,
+}: DraggableMemberProps) {
+  const { attributes, listeners, setNodeRef, isDragging } = useDraggable({ id });
+  const isLight = isLightColor(color);
+  const textColor = isLight ? "#1A1A1A" : "#FFFFFF";
+  const reducedMotion = useReducedMotion();
+
+  return (
+    <motion.div
+      ref={setNodeRef}
+      layoutId={id}
+      className="relative flex items-center justify-center px-3 py-2 text-sm font-bold text-center leading-tight select-none"
+      style={{
+        backgroundColor: locked ? color + "CC" : color,
+        color: textColor,
+        border: locked ? "3px dashed #1A1A1A" : "3px solid #1A1A1A",
+        borderRadius: "4px",
+        boxShadow: isDragging ? "none" : locked ? "none" : "3px 3px 0px #1A1A1A",
+        opacity: isDragging ? 0.4 : locked ? 0.8 : 1,
+        cursor: isDragging ? "grabbing" : "grab",
+        touchAction: "none",
+      }}
+      initial={reducedMotion ? false : { opacity: 0, y: 20 }}
+      animate={reducedMotion ? {} : { opacity: isDragging ? 0.4 : 1, y: 0 }}
+      transition={{ type: "spring", stiffness: 300, damping: 24 }}
+      {...listeners}
+      {...attributes}
+    >
+      <span className="truncate max-w-full">{name}</span>
+      {onToggleLock && (
+        <button
+          onClick={(e) => {
+            e.stopPropagation();
+            onToggleLock();
+          }}
+          className="absolute top-0.5 right-0.5 text-xs leading-none p-0.5"
+          style={{ opacity: locked ? 1 : 0.4, lineHeight: 1 }}
+          aria-label={locked ? "Unlock" : "Lock"}
+        >
+          {locked ? "🔒" : "🔓"}
+        </button>
+      )}
+    </motion.div>
+  );
+}

--- a/src/components/shuffler/ShuffleControls.tsx
+++ b/src/components/shuffler/ShuffleControls.tsx
@@ -6,7 +6,11 @@ interface ShuffleControlsProps {
   onReset: () => void;
   onShowTeams: () => void;
   onExport: () => void;
+  onHistoryBack?: () => void;
+  onHistoryForward?: () => void;
   hasResult: boolean;
+  canGoBack?: boolean;
+  canGoForward?: boolean;
   disabled?: boolean;
   copyConfirmed?: boolean;
 }
@@ -32,7 +36,11 @@ export default function ShuffleControls({
   onReset,
   onShowTeams,
   onExport,
+  onHistoryBack,
+  onHistoryForward,
   hasResult,
+  canGoBack = false,
+  canGoForward = false,
   disabled = false,
   copyConfirmed = false,
 }: ShuffleControlsProps) {
@@ -66,6 +74,65 @@ export default function ShuffleControls({
 
       {hasResult && (
         <>
+          {/* History navigation */}
+          <div className="flex gap-2">
+            <button
+              onClick={onHistoryBack}
+              disabled={!canGoBack}
+              aria-label="Previous shuffle"
+              style={{
+                ...legoButton.base,
+                flex: 1,
+                backgroundColor: canGoBack ? legoTheme.colors.orange : "#ccc",
+                color: canGoBack ? legoTheme.colors.white : "#888",
+                boxShadow: canGoBack ? legoTheme.shadow : "2px 2px 0px #999",
+                cursor: canGoBack ? "pointer" : "not-allowed",
+              }}
+              onMouseEnter={(e) => {
+                if (canGoBack) e.currentTarget.style.backgroundColor = "#D4681A";
+              }}
+              onMouseLeave={(e) => {
+                if (canGoBack) e.currentTarget.style.backgroundColor = legoTheme.colors.orange;
+              }}
+              onMouseDown={(e) => {
+                if (canGoBack) e.currentTarget.style.transform = "translate(2px, 2px)";
+              }}
+              onMouseUp={(e) => {
+                if (canGoBack) e.currentTarget.style.transform = "";
+              }}
+            >
+              ← Prev
+            </button>
+            <button
+              onClick={onHistoryForward}
+              disabled={!canGoForward}
+              aria-label="Next shuffle"
+              style={{
+                ...legoButton.base,
+                flex: 1,
+                backgroundColor: canGoForward ? legoTheme.colors.orange : "#ccc",
+                color: canGoForward ? legoTheme.colors.white : "#888",
+                boxShadow: canGoForward ? legoTheme.shadow : "2px 2px 0px #999",
+                cursor: canGoForward ? "pointer" : "not-allowed",
+              }}
+              onMouseEnter={(e) => {
+                if (canGoForward) e.currentTarget.style.backgroundColor = "#D4681A";
+              }}
+              onMouseLeave={(e) => {
+                if (canGoForward)
+                  e.currentTarget.style.backgroundColor = legoTheme.colors.orange;
+              }}
+              onMouseDown={(e) => {
+                if (canGoForward) e.currentTarget.style.transform = "translate(2px, 2px)";
+              }}
+              onMouseUp={(e) => {
+                if (canGoForward) e.currentTarget.style.transform = "";
+              }}
+            >
+              Next →
+            </button>
+          </div>
+
           {/* Copy + Show Teams side by side */}
           <div className="flex gap-2">
             <button
@@ -96,7 +163,9 @@ export default function ShuffleControls({
                 boxShadow: legoTheme.shadow,
               }}
               onMouseEnter={(e) => (e.currentTarget.style.backgroundColor = "#008040")}
-              onMouseLeave={(e) => (e.currentTarget.style.backgroundColor = legoTheme.colors.green)}
+              onMouseLeave={(e) =>
+                (e.currentTarget.style.backgroundColor = legoTheme.colors.green)
+              }
               onMouseDown={(e) => (e.currentTarget.style.transform = "translate(2px, 2px)")}
               onMouseUp={(e) => (e.currentTarget.style.transform = "")}
             >
@@ -136,7 +205,9 @@ export default function ShuffleControls({
               border: `2px solid #ccc`,
             }}
             onMouseEnter={(e) => (e.currentTarget.style.backgroundColor = "#f0f0f0")}
-            onMouseLeave={(e) => (e.currentTarget.style.backgroundColor = legoTheme.colors.white)}
+            onMouseLeave={(e) =>
+              (e.currentTarget.style.backgroundColor = legoTheme.colors.white)
+            }
             onMouseDown={(e) => (e.currentTarget.style.transform = "translate(2px, 2px)")}
             onMouseUp={(e) => (e.currentTarget.style.transform = "")}
           >

--- a/src/components/shuffler/TeamContainer.tsx
+++ b/src/components/shuffler/TeamContainer.tsx
@@ -1,7 +1,9 @@
 "use client";
 
 import { motion, useReducedMotion } from "framer-motion";
+import { useDroppable } from "@dnd-kit/core";
 import NameBlock from "./NameBlock";
+import DraggableMember from "./DraggableMember";
 
 interface TeamContainerProps {
   teamName: string;
@@ -10,7 +12,8 @@ interface TeamContainerProps {
   index: number;
   lockedNames?: Set<string>;
   onToggleLock?: (name: string) => void;
-  showName?: boolean; // if false, show only "Team N"
+  showName?: boolean;
+  draggable?: boolean;
 }
 
 const containerVariants = {
@@ -26,6 +29,7 @@ export default function TeamContainer({
   lockedNames,
   onToggleLock,
   showName = true,
+  draggable = false,
 }: TeamContainerProps) {
   const isLight = isLightColor(color);
   const headerTextColor = isLight ? "#1A1A1A" : "#FFFFFF";
@@ -33,15 +37,18 @@ export default function TeamContainer({
 
   const displayLabel = showName ? teamName : `Team ${index + 1}`;
 
+  const { setNodeRef, isOver } = useDroppable({ id: `team-${index}` });
+
   return (
     <motion.div
       role="region"
       aria-label={`Team ${index + 1}${showName ? `: ${teamName}` : ""}`}
       className="flex flex-col overflow-hidden"
       style={{
-        border: "3px solid #1A1A1A",
+        border: isOver ? `3px solid ${color}` : "3px solid #1A1A1A",
         borderRadius: "4px",
-        boxShadow: "4px 4px 0px #1A1A1A",
+        boxShadow: isOver ? `0 0 0 3px ${color}55, 4px 4px 0px #1A1A1A` : "4px 4px 0px #1A1A1A",
+        transition: "border-color 0.15s, box-shadow 0.15s",
       }}
       initial={reducedMotion ? false : { opacity: 0, scale: 0.95 }}
       animate={reducedMotion ? {} : { opacity: 1, scale: 1 }}
@@ -74,11 +81,32 @@ export default function TeamContainer({
         </span>
       </div>
 
-      <div className="p-3 grid gap-2" style={{ backgroundColor: "#F5F5F5" }}>
+      <div
+        ref={draggable ? setNodeRef : undefined}
+        className="p-3 grid gap-2"
+        style={{
+          backgroundColor: isOver ? "#EFEFEF" : "#F5F5F5",
+          minHeight: "48px",
+          transition: "background-color 0.15s",
+        }}
+      >
         {members.length === 0 ? (
           <p className="text-xs text-center py-2" style={{ color: "#999" }}>
             No members
           </p>
+        ) : draggable ? (
+          members.map((name, memberIndex) => (
+            <DraggableMember
+              key={`${index}-${name}-${memberIndex}`}
+              id={`${index}:${memberIndex}:${name}`}
+              name={name}
+              color={color}
+              teamIndex={index}
+              memberIndex={memberIndex}
+              locked={lockedNames?.has(name)}
+              onToggleLock={onToggleLock ? () => onToggleLock(name) : undefined}
+            />
+          ))
         ) : (
           members.map((name) => (
             <NameBlock

--- a/src/hooks/useShuffler.ts
+++ b/src/hooks/useShuffler.ts
@@ -1,6 +1,13 @@
-import { useState } from "react";
+import { useState, useCallback } from "react";
 import { shuffle } from "@/lib/shuffle";
 import { trackEvent } from "@/lib/analytics";
+
+const HISTORY_LIMIT = 5;
+
+interface HistoryEntry {
+  teams: string[][];
+  timestamp: string;
+}
 
 interface ValidationResult {
   nameList: string[];
@@ -34,6 +41,12 @@ function validate(names: string, teamCount: number): ValidationResult {
   return { nameList, duplicates, error, warning };
 }
 
+function pushHistory(history: HistoryEntry[], teams: string[][]): HistoryEntry[] {
+  const entry: HistoryEntry = { teams, timestamp: new Date().toISOString() };
+  const updated = [...history, entry];
+  return updated.length > HISTORY_LIMIT ? updated.slice(updated.length - HISTORY_LIMIT) : updated;
+}
+
 export function useShuffler() {
   const [names, setNames] = useState("");
   const [teamCount, setTeamCount] = useState(3);
@@ -42,7 +55,13 @@ export function useShuffler() {
   const [lockedNames, setLockedNames] = useState<Set<string>>(new Set());
   const [useTeamNames, setUseTeamNames] = useState(true);
 
+  const [history, setHistory] = useState<HistoryEntry[]>([]);
+  const [historyIndex, setHistoryIndex] = useState(-1);
+
   const validation = validate(names, teamCount);
+
+  const canGoBack = historyIndex > 0;
+  const canGoForward = historyIndex < history.length - 1;
 
   function toggleLock(name: string) {
     setLockedNames((prev) => {
@@ -51,6 +70,18 @@ export function useShuffler() {
       else next.add(name);
       return next;
     });
+  }
+
+  function applyResult(teams: string[][], fromHistory?: boolean) {
+    setResult(teams);
+    if (!fromHistory) {
+      setHistory((prev) => {
+        const truncated = prev.slice(0, historyIndex + 1);
+        const next = pushHistory(truncated, teams);
+        setHistoryIndex(next.length - 1);
+        return next;
+      });
+    }
   }
 
   function handleShuffle() {
@@ -64,12 +95,40 @@ export function useShuffler() {
       });
     }
     const { teams } = shuffle(validation.nameList, teamCount, { lockedAssignments });
-    setResult(teams);
+    applyResult(teams);
     trackEvent("shuffle", {
       team_count: teamCount,
       participant_count: validation.nameList.length,
     });
   }
+
+  function historyBack() {
+    if (!canGoBack) return;
+    const newIndex = historyIndex - 1;
+    setHistoryIndex(newIndex);
+    setResult(history[newIndex].teams);
+  }
+
+  function historyForward() {
+    if (!canGoForward) return;
+    const newIndex = historyIndex + 1;
+    setHistoryIndex(newIndex);
+    setResult(history[newIndex].teams);
+  }
+
+  const moveParticipant = useCallback(
+    (fromTeam: number, fromIndex: number, toTeam: number) => {
+      if (!result) return;
+      if (fromTeam === toTeam) return;
+
+      const next = result.map((team) => [...team]);
+      const [member] = next[fromTeam].splice(fromIndex, 1);
+      next[toTeam].push(member);
+      applyResult(next);
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [result, historyIndex]
+  );
 
   function handleCopy() {
     if (!result) return;
@@ -86,6 +145,8 @@ export function useShuffler() {
     setResult(null);
     setLockedNames(new Set());
     setCopyConfirmed(false);
+    setHistory([]);
+    setHistoryIndex(-1);
     trackEvent("reset");
   }
 
@@ -104,5 +165,12 @@ export function useShuffler() {
     validation,
     useTeamNames,
     setUseTeamNames,
+    history,
+    historyIndex,
+    canGoBack,
+    canGoForward,
+    historyBack,
+    historyForward,
+    moveParticipant,
   };
 }


### PR DESCRIPTION
## Summary

Implements two MVP features:

### #57 — Shuffle history (last 5)
- Extended `useShuffler` with a `history` array and `historyIndex` cursor
- Each entry stores full team result + timestamp — capped at 5 entries
- Exposes `historyBack`, `historyForward`, `canGoBack`, `canGoForward`
- Prev/Next buttons in `ShuffleControls` — visible after first shuffle
- Drag operations (issue #58) also push a history entry

### #58 — Drag-to-reassign team members
- `@dnd-kit/core` + `@dnd-kit/sortable` for accessible drag and drop
- Visual drop indicator on target team card during drag
- Touch device support via `TouchSensor`
- Each drag creates a new history entry
- `moveParticipant(fromTeam, fromIndex, toTeam)` exposed from `useShuffler`
- DnD context wraps team container area in `page.tsx`

## Closes
Fixes #57, #58