### PR TITLE
🧱 ci: auto-increment version on every merge to main

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -1,34 +1,152 @@
-name: Build and Push to Docker Hub
+name: "🧱 Build and Push to Docker Hub"
 
-# Builds and pushes the Docker image on merge to main and on releases.
-# Versioning: YY.MM.PATCH (e.g. 26.3.1) — create a git tag before releasing.
-# Dev: ArgoCD Image Updater picks up new tags automatically.
-# Prod: bump the tag in k8s/values-prod.yaml and push.
+# Runs on every merge to main — auto-increments version, tags, builds, pushes, creates release.
+# Manual dispatch allows forcing a specific version or triggering a build without a merge.
+#
+# Version format: YY.MM.PATCH (e.g. 26.3.3) — patch auto-increments on each merge.
+# Dev:  ArgoCD Image Updater picks up new semver tags automatically.
+# Prod: bump image.tag in k8s/values-prod.yaml and push.
 
 on:
   push:
     branches:
       - main
-  release:
-    types: [published]
   workflow_dispatch:
     inputs:
-      version_override:
-        description: "Override version tag (e.g. 26.3.1)"
+      force_version:
+        description: "Force specific version (e.g. 26.3.5)"
         required: false
         type: string
 
+concurrency:
+  group: ${{ github.workflow }}-on-merge
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  packages: write
+
 jobs:
-  build-and-push:
+  # ─────────────────────────────────────────────────────────────
+  # 🔍 DETECT SOURCE CHANGES
+  # ─────────────────────────────────────────────────────────────
+  detect-changes:
+    name: "🔍 Detect Source Changes"
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
+    outputs:
+      source-changed: ${{ steps.check.outputs.source-changed }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 2
+      - name: Check for source changes
+        id: check
+        run: |
+          CHANGED=$(git diff --name-only HEAD~1 HEAD)
+          echo "Changed files:"
+          echo "$CHANGED"
+          if echo "$CHANGED" | grep -qE "^(src/|public/|package\.json|package-lock\.json|tsconfig|next\.config|Dockerfile)"; then
+            echo "source-changed=true" >> $GITHUB_OUTPUT
+            echo "✅ Source files changed — full pipeline will run"
+          else
+            echo "source-changed=false" >> $GITHUB_OUTPUT
+            echo "⚡ No source changes — skipping Docker build"
+          fi
+
+  # ─────────────────────────────────────────────────────────────
+  # 🔢 CALCULATE VERSION
+  # ─────────────────────────────────────────────────────────────
+  gate-0-version:
+    name: "🔢 Calculate Version"
+    runs-on: ubuntu-latest
+    needs: [detect-changes]
+    if: needs.detect-changes.outputs.source-changed == 'true' || github.event_name == 'workflow_dispatch'
+    outputs:
+      new_version: ${{ steps.version.outputs.new_version }}
+      should_build: ${{ steps.check.outputs.should_build }}
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          fetch-depth: 0 # full history for tag-based versioning
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: "🔢 Calculate Version"
+        id: version
+        run: |
+          if [[ -n "${{ github.event.inputs.force_version }}" ]]; then
+            NEW_VERSION="${{ github.event.inputs.force_version }}"
+            if ! [[ "$NEW_VERSION" =~ ^[0-9]{2}\.[0-9]{1,2}\.[0-9]+$ ]]; then
+              echo "❌ Invalid version format: $NEW_VERSION (expected YY.MM.PATCH)"
+              exit 1
+            fi
+            echo "🎯 Forced version: $NEW_VERSION"
+            echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
+          else
+            chmod +x scripts/increment-version.sh
+            ./scripts/increment-version.sh
+            NEW_VERSION=$(grep "^new_version=" "$GITHUB_OUTPUT" | cut -d'=' -f2)
+          fi
+          echo "📋 Next version: $NEW_VERSION"
+
+      - name: "🔍 Check Version Uniqueness"
+        id: check
+        run: |
+          VERSION="${{ steps.version.outputs.new_version }}"
+          if git tag -l | grep -q "^${VERSION}$"; then
+            if [[ -n "${{ github.event.inputs.force_version }}" ]]; then
+              echo "🔄 Force mode — overwriting existing tag $VERSION"
+              echo "should_build=true" >> $GITHUB_OUTPUT
+            else
+              echo "⚠️ Tag $VERSION already exists — skipping"
+              echo "should_build=false" >> $GITHUB_OUTPUT
+            fi
+          else
+            echo "✅ New version: $VERSION"
+            echo "should_build=true" >> $GITHUB_OUTPUT
+          fi
+
+  # ─────────────────────────────────────────────────────────────
+  # 🏷️ TAG
+  # ─────────────────────────────────────────────────────────────
+  gate-1-tag:
+    name: "🏷️ Tag Release"
+    runs-on: ubuntu-latest
+    needs: gate-0-version
+    if: needs.gate-0-version.outputs.should_build == 'true'
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: "🏷️ Create & Push Git Tag"
+        env:
+          NEW_VERSION: ${{ needs.gate-0-version.outputs.new_version }}
+        run: |
+          git config user.email "action@github.com"
+          git config user.name "GitHub Action"
+          git tag -d "$NEW_VERSION" 2>/dev/null || true
+          git tag -a "$NEW_VERSION" -m "Release $NEW_VERSION
+
+          Automatic release from main branch merge.
+          Build: GitHub Actions #${GITHUB_RUN_NUMBER}
+          Commit: ${GITHUB_SHA:0:8}
+          Date: $(date -u +"%Y-%m-%d %H:%M:%S UTC")"
+          git push origin "$NEW_VERSION" --force
+          echo "✅ Tag $NEW_VERSION pushed"
+
+  # ─────────────────────────────────────────────────────────────
+  # 🐳 BUILD & PUSH
+  # ─────────────────────────────────────────────────────────────
+  build-push:
+    name: "🐳 Build & Push Docker Image"
+    runs-on: ubuntu-latest
+    needs: [gate-0-version, gate-1-tag]
+    if: needs.gate-0-version.outputs.should_build == 'true'
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
@@ -39,63 +157,88 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Determine image tags
-        id: tags
-        run: |
-          IMAGE="bonditgroup/team-shuffler-frontend"
-
-          if [[ "${{ github.event_name }}" == "release" ]]; then
-            RELEASE_TAG="${{ github.event.release.tag_name }}"
-            {
-              echo "tags=${IMAGE}:${RELEASE_TAG},${IMAGE}:latest"
-              echo "primary_tag=${RELEASE_TAG}"
-            } >> "$GITHUB_OUTPUT"
-
-          elif [[ -n "${{ github.event.inputs.version_override }}" ]]; then
-            VERSION_TAG="${{ github.event.inputs.version_override }}"
-            {
-              echo "tags=${IMAGE}:${VERSION_TAG},${IMAGE}:latest"
-              echo "primary_tag=${VERSION_TAG}"
-            } >> "$GITHUB_OUTPUT"
-
-          else
-            # Push to main — find latest semantic version tag for current month
-            git fetch --tags
-            CURRENT_MONTH=$(date +"%y.%-m")
-            LATEST_TAG=$(git tag -l "${CURRENT_MONTH}.*" | sort -V | tail -1)
-
-            if [[ -n "$LATEST_TAG" ]]; then
-              {
-                echo "tags=${IMAGE}:${LATEST_TAG},${IMAGE}:latest"
-                echo "primary_tag=${LATEST_TAG}"
-              } >> "$GITHUB_OUTPUT"
-            else
-              {
-                echo "tags=${IMAGE}:latest"
-                echo "primary_tag=latest"
-              } >> "$GITHUB_OUTPUT"
-            fi
-          fi
-
       - name: Build and push Docker image
         uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
         with:
           context: .
           file: ./Dockerfile
           push: true
-          tags: ${{ steps.tags.outputs.tags }}
+          tags: |
+            bonditgroup/team-shuffler-frontend:${{ needs.gate-0-version.outputs.new_version }}
+            bonditgroup/team-shuffler-frontend:latest
           platforms: linux/amd64
           build-args: |
-            APP_VERSION=${{ steps.tags.outputs.primary_tag }}
+            APP_VERSION=${{ needs.gate-0-version.outputs.new_version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Summary
+  # ─────────────────────────────────────────────────────────────
+  # 📦 GITHUB RELEASE
+  # ─────────────────────────────────────────────────────────────
+  gate-3-release:
+    name: "📦 Create GitHub Release"
+    runs-on: ubuntu-latest
+    needs: [gate-0-version, gate-1-tag, build-push]
+    if: needs.gate-0-version.outputs.should_build == 'true'
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: "📦 Create GitHub Release"
+        env:
+          NEW_VERSION: ${{ needs.gate-0-version.outputs.new_version }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          cat > release_notes.md << EOF
+          # Release ${NEW_VERSION}
+
+          **Date:** $(date +"%Y-%m-%d")
+          **Commit:** ${GITHUB_SHA:0:8}
+
+          ## Docker Image
+
+          \`\`\`
+          bonditgroup/team-shuffler-frontend:${NEW_VERSION}
+          \`\`\`
+
+          ## Deployment
+
+          Dev auto-deploys via ArgoCD Image Updater.
+          Prod: bump \`image.tag\` in \`k8s/values-prod.yaml\` and push.
+          EOF
+
+          gh release create "$NEW_VERSION" \
+            --title "Release $NEW_VERSION" \
+            --notes-file release_notes.md \
+            --target main
+          echo "✅ GitHub release $NEW_VERSION created"
+
+  # ─────────────────────────────────────────────────────────────
+  # 📋 SUMMARY
+  # ─────────────────────────────────────────────────────────────
+  gate-4-summary:
+    name: "📋 Summary"
+    runs-on: ubuntu-latest
+    needs: [gate-0-version, gate-1-tag, build-push, gate-3-release]
+    if: always()
+
+    steps:
+      - name: "📋 Generate Summary"
+        env:
+          NEW_VERSION: ${{ needs.gate-0-version.outputs.new_version }}
         run: |
           {
-            echo "## Build Summary 🧱"
-            echo "**Image:** bonditgroup/team-shuffler-frontend"
-            echo "**Tags:** ${{ steps.tags.outputs.tags }}"
-            echo "**Commit:** ${{ github.sha }}"
-            echo "**Triggered by:** ${{ github.event_name }}"
+            echo "## 🧱 Build Summary"
+            echo ""
+            echo "| Step | Result |"
+            echo "|------|--------|"
+            echo "| 🔢 Version | \`$NEW_VERSION\` |"
+            echo "| 🏷️ Tag | ${{ needs.gate-1-tag.result }} |"
+            echo "| 🐳 Docker Build | ${{ needs.build-push.result }} |"
+            echo "| 📦 GitHub Release | ${{ needs.gate-3-release.result }} |"
+            echo ""
+            echo "**Image:** \`bonditgroup/team-shuffler-frontend:$NEW_VERSION\`"
+            echo "**ArgoCD:** Dev auto-syncs. Prod: bump \`k8s/values-prod.yaml\` → push."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/increment-version.sh
+++ b/scripts/increment-version.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# Version increment script for team-shuffler
+# Calculates next patch version based on existing git tags (YY.MM.PATCH format)
+
+set -euo pipefail
+
+get_current_month() {
+    date +"%y.%-m"
+}
+
+get_latest_version() {
+    local current_month=$1
+    local tags
+    tags=$(git tag -l "${current_month}.*" | sort -V | tail -1)
+    if [[ -z "$tags" ]]; then
+        echo "${current_month}.0"
+    else
+        echo "$tags"
+    fi
+}
+
+increment_patch() {
+    local version=$1
+    local year_month
+    year_month=$(echo "$version" | cut -d. -f1,2)
+    local patch
+    patch=$(echo "$version" | cut -d. -f3)
+    local new_patch=$((patch + 1))
+    echo "${year_month}.${new_patch}"
+}
+
+echo "🔍 Calculating next version..."
+
+CURRENT_MONTH=$(get_current_month)
+echo "📅 Current month: $CURRENT_MONTH"
+
+LATEST_VERSION=$(get_latest_version "$CURRENT_MONTH")
+echo "📋 Latest version: $LATEST_VERSION"
+
+LATEST_MONTH=$(echo "$LATEST_VERSION" | cut -d. -f1,2)
+
+if [[ "$CURRENT_MONTH" == "$LATEST_MONTH" ]]; then
+    NEW_VERSION=$(increment_patch "$LATEST_VERSION")
+    echo "⬆️ Incrementing patch version"
+else
+    NEW_VERSION="${CURRENT_MONTH}.0"
+    echo "📅 New month — starting fresh"
+fi
+
+echo "🎯 Next version: $NEW_VERSION"
+
+if ! [[ "$NEW_VERSION" =~ ^[0-9]{2}\.[0-9]{1,2}\.[0-9]+$ ]]; then
+    echo "❌ Invalid version format: $NEW_VERSION"
+    exit 1
+fi
+
+if [[ "${GITHUB_ACTIONS:-false}" == "true" ]]; then
+    echo "new_version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
+    echo "latest_version=$LATEST_VERSION" >> "$GITHUB_OUTPUT"
+    echo "current_month=$CURRENT_MONTH" >> "$GITHUB_OUTPUT"
+fi
+
+echo "✅ Version calculation complete: $LATEST_VERSION → $NEW_VERSION"


### PR DESCRIPTION
## Problem

The `build-and-push.yml` workflow was reusing the latest existing git tag on every push to `main` instead of creating a new one. This meant ArgoCD Image Updater (semver strategy) saw no version bump and never deployed.

## Fix

Ported the same auto-versioning pattern from `consultant-portal-frontend`:

- Added `scripts/increment-version.sh` — calculates next patch version (`YY.MM.PATCH`) by finding the latest tag for the current month and incrementing the patch number
- Rewrote `build-and-push.yml` with the same gated pipeline structure:
  - **detect-changes** — skips build if only CI/docs changed
  - **gate-0-version** — runs `increment-version.sh`, skips if tag already exists
  - **gate-1-tag** — creates and pushes the new git tag
  - **build-push** — builds Docker image tagged with new version + latest
  - **gate-3-release** — creates GitHub release
  - **gate-4-summary** — always runs

## Result

Every merge to `main` that touches source files now produces a new semver tag (e.g. `26.3.3`), which ArgoCD Image Updater picks up and deploys to dev automatically.