### PR TITLE
✨ fix: encode team data in URL so QR code works on any device

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -79,8 +79,11 @@ export default function Home() {
       teamNames: TEAM_NAMES,
       useTeamNames,
     };
+    // Store in localStorage for local use
     localStorage.setItem("team-shuffler-presentation", JSON.stringify(payload));
-    window.open("/present", "_blank", "noopener");
+    // Also encode into URL so QR code recipients can view without localStorage
+    const encoded = btoa(encodeURIComponent(JSON.stringify(payload)));
+    window.open(`/present?data=${encoded}`, "_blank", "noopener");
     trackEvent("present_teams");
   }
 

--- a/src/app/present/page.tsx
+++ b/src/app/present/page.tsx
@@ -34,16 +34,30 @@ export default function PresentPage() {
 
   useEffect(() => {
     try {
+      // Try URL param first (for QR code / shared links)
+      const params = new URLSearchParams(window.location.search);
+      const encoded = params.get("data");
+      if (encoded) {
+        const parsed = JSON.parse(decodeURIComponent(atob(encoded)));
+        setData(parsed);
+        setPageUrl(window.location.href);
+        return;
+      }
+      // Fall back to localStorage (local "Show Teams" flow without data param)
       const raw = localStorage.getItem("team-shuffler-presentation");
       if (!raw) {
         setError(true);
         return;
       }
-      setData(JSON.parse(raw));
+      const parsed = JSON.parse(raw);
+      // Re-encode into URL so the QR code on this page also works for sharing
+      const reEncoded = btoa(encodeURIComponent(JSON.stringify(parsed)));
+      const shareUrl = `${window.location.origin}/present?data=${reEncoded}`;
+      setData(parsed);
+      setPageUrl(shareUrl);
     } catch {
       setError(true);
     }
-    setPageUrl(window.location.href);
   }, []);
 
   if (error) {


### PR DESCRIPTION
## Problem
The QR code on the `/present` view pointed to the current URL (`/present`), but team data was only stored in `localStorage`. Scanning the QR on another device opened a blank page with "No team data found".

## Fix
Team data is now encoded as a base64 URL parameter:
- `handleShowTeams` in `page.tsx` encodes the payload as `btoa(encodeURIComponent(JSON.stringify(...)))` and opens `/present?data=...`
- `/present` reads from the `?data` param first; falls back to `localStorage` if absent
- When falling back to localStorage (old flow), it re-encodes the data into the URL so the QR code on *that* page also generates a shareable link

## Result
Scan the QR on your phone → full team view, no backend needed. The entire state lives in the URL.

## Closes
Fixes the QR code sharing issue.