### PR TITLE
bump version to 26.4.3

### DIFF
--- a/k8s/values-prod.yaml
+++ b/k8s/values-prod.yaml
@@ -5,7 +5,7 @@
 environment: "production"
 
 image:
-  tag: "26.3.9" # ← bump this to deploy a new version
+  tag: "26.4.3" # ← bump this to deploy a new version
   pullPolicy: IfNotPresent
 
 replicaCount: 2


### PR DESCRIPTION
Deploys `bonditgroup/team-shuffler-frontend:26.4.3` to production.\n\nMerge → ArgoCD syncs automatically.